### PR TITLE
feat: add integration settings route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Smart Rain</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "smart-rain",
+  "version": "1.0.0",
+  "description": "- Centralizes rainfall data and reporting to help users make informed water management decisions. - Provides a unified interface for administrators to manage content and commerce data.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "test": "echo \"No tests configured\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.2"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import SettingsIntegrations from './routes/SettingsIntegrations';
+
+export default function App() {
+  return (
+    <Router>
+      <Routes>
+        <Route path="/settings/integrations" element={<SettingsIntegrations />} />
+      </Routes>
+    </Router>
+  );
+}

--- a/src/components/IntegrationCard.tsx
+++ b/src/components/IntegrationCard.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export interface IntegrationCardProps {
+  name: string;
+  status: string;
+  uptime: string;
+  errorRate: string;
+  lastSync: string;
+  nextSync: string;
+  authMethod: string;
+  onTestConnection: () => Promise<void>;
+  onTriggerSync: () => Promise<void>;
+}
+
+export function IntegrationCard({
+  name,
+  status,
+  uptime,
+  errorRate,
+  lastSync,
+  nextSync,
+  authMethod,
+  onTestConnection,
+  onTriggerSync,
+}: IntegrationCardProps) {
+  return (
+    <div className="border rounded p-4 mb-4">
+      <h2 className="text-xl font-semibold mb-2">{name}</h2>
+      <p>Status: {status}</p>
+      <p>Uptime: {uptime}</p>
+      <p>Error rate: {errorRate}</p>
+      <p>Last sync: {lastSync}</p>
+      <p>Next sync: {nextSync}</p>
+      <p>Auth method: {authMethod}</p>
+      <div className="mt-2 flex gap-2">
+        <button onClick={onTestConnection} className="px-2 py-1 border rounded">
+          Test Connection
+        </button>
+        <button onClick={onTriggerSync} className="px-2 py-1 border rounded">
+          Trigger Sync
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/src/routes/SettingsIntegrations.tsx
+++ b/src/routes/SettingsIntegrations.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { IntegrationCard } from '../components/IntegrationCard';
+
+interface StatusResponse {
+  status: string;
+  uptime: string;
+  errorRate: string;
+  lastSync: string;
+  nextSync: string;
+  authMethod: string;
+}
+
+async function fetchStatus(endpoint: string): Promise<StatusResponse> {
+  const res = await fetch(endpoint);
+  if (!res.ok) {
+    throw new Error('Failed to load status');
+  }
+  return res.json();
+}
+
+const placeholder: StatusResponse = {
+  status: 'unknown',
+  uptime: '0%',
+  errorRate: '0%',
+  lastSync: '-',
+  nextSync: '-',
+  authMethod: '-',
+};
+
+export default function SettingsIntegrations() {
+  const [pantheon, setPantheon] = useState<StatusResponse>(placeholder);
+  const [merchant, setMerchant] = useState<StatusResponse>(placeholder);
+
+  useEffect(() => {
+    fetchStatus('/api/pantheon/status').then(setPantheon).catch(() => null);
+    fetchStatus('/api/merchantpro/status').then(setMerchant).catch(() => null);
+  }, []);
+
+  const testPantheon = async () => {
+    await fetch('/api/pantheon/test', { method: 'POST' });
+    setPantheon(await fetchStatus('/api/pantheon/status'));
+  };
+
+  const syncPantheon = async () => {
+    await fetch('/api/pantheon/sync', { method: 'POST' });
+    setPantheon(await fetchStatus('/api/pantheon/status'));
+  };
+
+  const testMerchant = async () => {
+    await fetch('/api/merchantpro/test', { method: 'POST' });
+    setMerchant(await fetchStatus('/api/merchantpro/status'));
+  };
+
+  const syncMerchant = async () => {
+    await fetch('/api/merchantpro/sync', { method: 'POST' });
+    setMerchant(await fetchStatus('/api/merchantpro/status'));
+  };
+
+  return (
+    <div className="p-4">
+      {pantheon && (
+        <IntegrationCard
+          name="Pantheon"
+          status={pantheon.status}
+          uptime={pantheon.uptime}
+          errorRate={pantheon.errorRate}
+          lastSync={pantheon.lastSync}
+          nextSync={pantheon.nextSync}
+          authMethod={pantheon.authMethod}
+          onTestConnection={testPantheon}
+          onTriggerSync={syncPantheon}
+        />
+      )}
+      {merchant && (
+        <IntegrationCard
+          name="MerchantPro"
+          status={merchant.status}
+          uptime={merchant.uptime}
+          errorRate={merchant.errorRate}
+          lastSync={merchant.lastSync}
+          nextSync={merchant.nextSync}
+          authMethod={merchant.authMethod}
+          onTestConnection={testMerchant}
+          onTriggerSync={syncMerchant}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add React app scaffold
- add integrations settings route for Pantheon and MerchantPro
- include cards with status info and actions to test connection or sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcceec8f8083318cc69a6c749b2400